### PR TITLE
openAIAPIにロールを与えて、ユーザーが文章を入力するだけでその続きを考えてくれるように。文字制限も140字程度に設定した。

### DIFF
--- a/app/src/main/java/com/example/dreamarchive/ui/screen/talk/TalkViewModel.kt
+++ b/app/src/main/java/com/example/dreamarchive/ui/screen/talk/TalkViewModel.kt
@@ -43,6 +43,7 @@ class TalkViewModel: ViewModel() {
             try {
                 val request = GptRequest(
                     messages = listOf(
+                        GptMessage("system", "あなたは作家です。今からユーザーが今朝見た夢の内容を入力するので、その続きの物語を140字程度で考えてください。必ず140字程度という文字制限を守ってください。"),
                         GptMessage("user", inputText)
                     )
                 )


### PR DESCRIPTION
Close #4 

- chatGPTに送るリクエストのシステムロールに設定を追加
- 文字制限を140字程度で指定することで完結な物語が生成されるように