### PR TITLE
SettingScreenのトグルボタンでいい夢モードを切り替えられるように。ただし、設定画面から移動するといい夢モードのオンオフが切り替えられない

### DIFF
--- a/app/src/main/java/com/example/dreamarchive/ui/screen/setting/SettingScreen.kt
+++ b/app/src/main/java/com/example/dreamarchive/ui/screen/setting/SettingScreen.kt
@@ -1,6 +1,8 @@
 package com.example.dreamarchive.ui.screen.setting
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -11,16 +13,24 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingScreen(
-    navController: NavController
+    navController: NavController,
+    settingViewModel: SettingViewModel = viewModel() // ViewModelを取得
 ){
+    // ViewModelの状態を監視
+    val isGoodDreamMode by settingViewModel.isGoodDreamMode.collectAsState()
+
     Scaffold(
             topBar = {
                 CenterAlignedTopAppBar(
@@ -45,7 +55,17 @@ fun SettingScreen(
         Column (
             modifier = Modifier.padding(paddingValues)
         ){
-            Text(text = "This is the setting screen.")
+            Row (
+                modifier = Modifier.fillMaxWidth()
+            ){
+                Text(text = "いい夢モード")
+                Switch(
+                    checked = isGoodDreamMode,
+                    onCheckedChange = { enabled ->
+                        settingViewModel.toggleGoodDreamMode(enabled) // 状態を更新
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/dreamarchive/ui/screen/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/example/dreamarchive/ui/screen/setting/SettingViewModel.kt
@@ -1,4 +1,21 @@
 package com.example.dreamarchive.ui.screen.setting
 
-class SettingViewModel {
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class SettingViewModel : ViewModel() {
+
+    // MutableStateFlowでトグルボタンの状態を保持
+    private val _isGoodDreamMode = MutableStateFlow(false)
+    val isGoodDreamMode: StateFlow<Boolean> = _isGoodDreamMode
+
+    // トグルボタンの状態を変更する関数
+    fun toggleGoodDreamMode(enabled: Boolean) {
+        viewModelScope.launch {
+            _isGoodDreamMode.value = enabled
+        }
+    }
 }

--- a/app/src/main/java/com/example/dreamarchive/ui/screen/talk/TalkScreen.kt
+++ b/app/src/main/java/com/example/dreamarchive/ui/screen/talk/TalkScreen.kt
@@ -33,13 +33,15 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import com.example.dreamarchive.ui.screen.setting.SettingViewModel
 
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TalkScreen(
-        navController: NavController,
-        talkViewModel: TalkViewModel = viewModel()
+    navController: NavController,
+    settingViewModel: SettingViewModel = viewModel(),  // 設定のViewModelを取得
+    talkViewModel: TalkViewModel = viewModel(factory = TalkViewModelFactory(settingViewModel)) // TalkViewModelに設定のViewModelを渡す
 ) {
 
     val messages by talkViewModel.messages.collectAsState()


### PR DESCRIPTION
Close #28 
- トグルボタンの設置
- オンにするとハッピーエンドのみになる
- トグルボタンのオンオフが画面遷移で保存されないので、別issue立てる必要あり