### PR TITLE
GPTのモデルを4-turboに変更。MeshyAPIもproプランに課金した。

### DIFF
--- a/app/src/main/java/com/example/dreamarchive/model/ChatGpt/GptRequest.kt
+++ b/app/src/main/java/com/example/dreamarchive/model/ChatGpt/GptRequest.kt
@@ -1,7 +1,7 @@
 package com.example.dreamarchive.model.ChatGpt
 
 data class GptRequest(
-    val model: String = "gpt-3.5-turbo",
+    val model: String = "gpt-4-turbo",
     val messages: List<GptMessage>
 )
 


### PR DESCRIPTION
Close #3 
Close #40 

- chatGPTのモデルを3.5-turboから4-turboへ変更
- MeshyAPIもProプランへ移行 